### PR TITLE
Centered dragged cards horizontally by replacing images with text icons.

### DIFF
--- a/src/components/dragged-item.vue
+++ b/src/components/dragged-item.vue
@@ -54,6 +54,8 @@
 	const top = computed(() => `${ y.value }px`);
 	const offsetX = computed(() => `${ -(dragged.value?.height ?? 0) / 2 }px`);
 	const offsetY = computed(() => `${ -(dragged.value?.height ?? 0) / 2 }px`);
+	const width = computed(() => `${dragged.value?.width}px`);
+	const height = computed(() => `${dragged.value?.height}px`);
 
 	const angles = computed(() => ({
 		x: `${ Math.tan(previousResults.reduce((acc, {x}) => acc + x, 0) / (previousResults.length * 50)) }rad`,
@@ -69,8 +71,9 @@
 	<div v-if="isDragging" class="dragging-viewport">
 		<div class="dragged">
 			<Component :is="dragged.component" v-if="dragged?.type === 'component'"/>
-			<img v-if="dragged?.type === 'image'" :height="dragged.height" :src="dragged.src" :width="dragged.width"
-					 alt="drop image" aria-hidden="true">
+			<span v-if="dragged?.type === 'emoji'" class="emoji">
+				{{ dragged.char }}	
+			</span>
 		</div>
 	</div>
 </template>
@@ -92,6 +95,14 @@
 		left: v-bind(offsetX);
 		transform: rotateZ(v-bind(angles.x)) rotateX(v-bind(angles.y));
 		transition: rotate linear 100ms;
+		width: v-bind(width);
+		height: v-bind(height);
+		display: grid;
+		place-content: center;
+	}
+
+	.emoji {
+		font-size: 5rem;
 	}
 
 </style>

--- a/src/components/hand-card.vue
+++ b/src/components/hand-card.vue
@@ -26,8 +26,8 @@
 
 	function dragStart(event: DragEvent) {
 		draggable.start({
-			type: 'image',
-			src: `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text x=%22-0.06em%22 y=%221em%22 font-size=%2278%22>${ card.icon }</text></svg>`,
+			type: 'emoji',
+			char: card.icon,
 			height: 120,
 			width: 120
 		}, {

--- a/src/stores/draggable.store.ts
+++ b/src/stores/draggable.store.ts
@@ -11,6 +11,11 @@ export type DraggedElement = {
 	src: string,
 	width: number,
 	height: number,
+} | {
+	type: 'emoji'
+	char: string,
+	width: number,
+	height: number,
 }
 
 export type DragOptions = {


### PR DESCRIPTION
I noticed that some dragged cards are off-center. 
You turn the icons into images.
I used the icons instead.

This PR is merely for practice, as I assume you will want to keep the setup for images. 

<img width="989" height="672" alt="image" src="https://github.com/user-attachments/assets/72795f65-7db0-412f-a42f-79cd085dbe33" />
